### PR TITLE
Update FlxRandom.hx shuffle

### DIFF
--- a/flixel/math/FlxRandom.hx
+++ b/flixel/math/FlxRandom.hx
@@ -335,7 +335,7 @@ class FlxRandom
 	public function shuffle<T>(array:Array<T>):Void
 	{
 		var maxValidIndex = array.length - 1;
-		for (i in 0...array.length)
+		for (i in 0...maxValidIndex)
 		{
 			var j = int(i, maxValidIndex);
 			var tmp = array[i];


### PR DESCRIPTION
Thanks for including the improved shuffle algorithm in HaxeFlixel. The implementation is slightly sub-optimal, in that the for loop (i) should stop one iteration earlier (at maxValidIndex - 1). Otherwise you end up pointlessly exchanging the last array element with the same last array element.